### PR TITLE
Refactor to make extsub.py more procedural

### DIFF
--- a/extsub.py
+++ b/extsub.py
@@ -22,53 +22,6 @@ from dashboard import update_dashboard
 import pickle
 import io
 
-#get absolute path of this script
-abs_path = os.path.dirname(os.path.abspath(__file__)) + "/"
-
-#read from configuration file
-config = ConfigParser.ConfigParser()
-config.readfp(open(abs_path + 'config.txt', 'r'))
-default_lang = config.get('extsub config', 'default_lang')
-launch_state = config.get('extsub config', 'launch_state')
-video = abs_path + config.get('extsub config', 'video_filename')
-subtitle_directory = abs_path + config.get('extsub config', 'subtitle_directory')
-
-#initiate assorted variables for tracking subtitle duration
-subtitle_duration = config.get('extsub config', 'subtitle_duration')
-played_through_once = False
-sub_start_position = ""
-
-#create/write over .count_plays (number of playthroughs)
-f = open(abs_path + '.count_plays', 'w')
-f.write("0")
-f.close()
-
-#set up serial connection to Arduino
-ports = list(serial.tools.list_ports.comports())
-for p in ports:
-  if "ACM" in str(p):
-    arduino_port = str(p)[:12]
-ser=s.Serial(arduino_port, .9600)
-time.sleep(3)
-
-#set language, first from command line, otherwise from config.txt
-if(len(sys.argv) > 1):
-	language = sys.argv[1]
-else:
-	language = default_lang
-
-#send language to Arduino
-ser.write("{LANGUAGE" + langdict[language] + language + "}")
-
-#send default display state to Arduino
-ser.write("{DEFAULT" + launch_state + "}")
-
-#setup default display info
-if(launch_state == "subtitles"):
-	write_subtitles = True
-else:
-	write_subtitles = False
-
 #function converts timecode to milliseconds
 def tc_to_ms(s):
         hours, minutes, seconds = (["0", "0"] + s.split(":"))[-3:]
@@ -114,110 +67,162 @@ def next_language(channel):
 		else:
 
 			j += 1
-#setup button
-GPIO.setmode(GPIO.BCM)
-GPIO.setup(21, GPIO.IN, pull_up_down=GPIO.PUD_UP) #GPIO21 = pin 40
-GPIO.add_event_detect(21, GPIO.FALLING, callback=next_language, bouncetime=200)
 
-#start omxplayer
-cmd = "omxplayer -o local --no-osd --loop %s" %(video)
-Popen([cmd], shell=True)
+def main():
+	#get absolute path of this script
+	abs_path = os.path.dirname(os.path.abspath(__file__)) + "/"
 
-#start dbus
-done, retry = 0, 0
-while done==0:
-	try:
-		with open('/tmp/omxplayerdbus.' + getpass.getuser(), 'r+') as f:
-			omxplayerdbus = f.read().strip()
-		bus = dbus.bus.BusConnection(omxplayerdbus)
-		object = bus.get_object('org.mpris.MediaPlayer2.omxplayer','/org/mpris/MediaPlayer2', introspect=False)
-		dbusIfaceProp = dbus.Interface(object,'org.freedesktop.DBus.Properties')
-		dbusIfaceKey = dbus.Interface(object,'org.mpris.MediaPlayer2.Player')
-		#disable in-player subtitles on video
-		dbusIfaceKey.Action(dbus.Int32("30"))
-		done=1
-	except:
-		retry+=1
-		if retry >= 5000:
-			print "ERROR"
-			raise SystemExit
+	#read from configuration file
+	config = ConfigParser.ConfigParser()
+	config.readfp(open(abs_path + 'config.txt', 'r'))
+	default_lang = config.get('extsub config', 'default_lang')
+	launch_state = config.get('extsub config', 'launch_state')
+	video = abs_path + config.get('extsub config', 'video_filename')
+	subtitle_directory = abs_path + config.get('extsub config', 'subtitle_directory')
 
-#import SRT subtitle files into one "subtitles" dict
-subtitles = collections.OrderedDict()
-os.chdir(subtitle_directory)
+	#initiate assorted variables for tracking subtitle duration
+	subtitle_duration = config.get('extsub config', 'subtitle_duration')
+	played_through_once = False
+	sub_start_position = ""
 
-#first add default language
-for subs in glob.glob("*.srt"):
-        lang = subs.split('.')[1]
-	if(lang == default_lang):
-	        with io.open(subs, "r", encoding="utf-8-sig") as myfile:
-	                subfile = myfile.read()
-	        subtitle_generator = srt.parse(subfile)
-	        subtitles[lang] = list(subtitle_generator)
+	#create/write over .count_plays (number of playthroughs)
+	f = open(abs_path + '.count_plays', 'w')
+	f.write("0")
+	f.close()
 
-#then add other languages
-for subs in glob.glob("*.srt"):
-	lang = subs.split('.')[1]
-	with io.open(subs, "r", encoding="utf-8-sig") as myfile:
-		subfile = myfile.read()
-	subtitle_generator = srt.parse(subfile)
-	subtitles[lang] = list(subtitle_generator)
+	#set up serial connection to Arduino
+	ports = list(serial.tools.list_ports.comports())
+	for p in ports:
+	  if "ACM" in str(p):
+	    arduino_port = str(p)[:12]
+	ser=s.Serial(arduino_port, .9600)
+	time.sleep(3)
 
-#iterate through and print subtitles	
-i = 0
-next_i = 0
-position = "0"
-duration = "0"
-while duration == "0":
-	try:
-		duration = chop_digits(str(dbusIfaceProp.Duration()))
-	except:
-		pass
+	#set language, first from command line, otherwise from config.txt
+	if(len(sys.argv) > 1):
+		language = sys.argv[1]
+	else:
+		language = default_lang
 
-while long(duration) > long(position):
-	start = tc_to_ms(str(subtitles[language][i].start))
-	end = tc_to_ms(str(subtitles[language][i].end))
-	position = chop_digits(str(dbusIfaceProp.Position()))
+	#send language to Arduino
+	ser.write("{LANGUAGE" + langdict[language] + language + "}")
 
-	#return to default if subtitle_duration 2 cases are met
-	if subtitle_duration == "2" and write_subtitles == True and played_through_once == True:
-		if long(position) > long(sub_start_position):
-			write_subtitles = False
-			ser.write("{DEFAULT" + launch_state + "}")
+	#send default display state to Arduino
+	ser.write("{DEFAULT" + launch_state + "}")
 
-	if long(position) > long(start) and long(position) <= long(end):
-		if i > next_i:
-			next_i += 1
-		elif i == next_i:
-			#requires write_subtitles = True to account for launch_state
-			if write_subtitles == True:
-				ser.write(subtitles[language][i].content.encode("utf-8") + "\r")
-			next_i += 1
-	elif long(position) > long(end):
-		if subtitles[language][i] == subtitles[language][-1]:
+	#setup default display info
+	if(launch_state == "subtitles"):
+		write_subtitles = True
+	else:
+		write_subtitles = False
+
+	#setup button
+	GPIO.setmode(GPIO.BCM)
+	GPIO.setup(21, GPIO.IN, pull_up_down=GPIO.PUD_UP) #GPIO21 = pin 40
+	GPIO.add_event_detect(21, GPIO.FALLING, callback=next_language, bouncetime=200)
+
+	#start omxplayer
+	cmd = "omxplayer -o local --no-osd --loop %s" %(video)
+	Popen([cmd], shell=True)
+
+	#start dbus
+	done, retry = 0, 0
+	while done==0:
+		try:
+			with open('/tmp/omxplayerdbus.' + getpass.getuser(), 'r+') as f:
+				omxplayerdbus = f.read().strip()
+			bus = dbus.bus.BusConnection(omxplayerdbus)
+			object = bus.get_object('org.mpris.MediaPlayer2.omxplayer','/org/mpris/MediaPlayer2', introspect=False)
+			dbusIfaceProp = dbus.Interface(object,'org.freedesktop.DBus.Properties')
+			dbusIfaceKey = dbus.Interface(object,'org.mpris.MediaPlayer2.Player')
+			#disable in-player subtitles on video
+			dbusIfaceKey.Action(dbus.Int32("30"))
+			done=1
+		except:
+			retry+=1
+			if retry >= 5000:
+				print "ERROR"
+				raise SystemExit
+
+	#import SRT subtitle files into one "subtitles" dict
+	subtitles = collections.OrderedDict()
+	os.chdir(subtitle_directory)
+
+	#first add default language
+	for subs in glob.glob("*.srt"):
+	        lang = subs.split('.')[1]
+		if(lang == default_lang):
+		        with io.open(subs, "r", encoding="utf-8-sig") as myfile:
+		                subfile = myfile.read()
+		        subtitle_generator = srt.parse(subfile)
+		        subtitles[lang] = list(subtitle_generator)
+
+	#then add other languages
+	for subs in glob.glob("*.srt"):
+		lang = subs.split('.')[1]
+		with io.open(subs, "r", encoding="utf-8-sig") as myfile:
+			subfile = myfile.read()
+		subtitle_generator = srt.parse(subfile)
+		subtitles[lang] = list(subtitle_generator)
+
+	#iterate through and print subtitles	
+	i = 0
+	next_i = 0
+	position = "0"
+	duration = "0"
+	while duration == "0":
+		try:
+			duration = chop_digits(str(dbusIfaceProp.Duration()))
+		except:
+			pass
+
+	while long(duration) > long(position):
+		start = tc_to_ms(str(subtitles[language][i].start))
+		end = tc_to_ms(str(subtitles[language][i].end))
+		position = chop_digits(str(dbusIfaceProp.Position()))
+
+		#return to default if subtitle_duration 2 cases are met
+		if subtitle_duration == "2" and write_subtitles == True and played_through_once == True:
+			if long(position) > long(sub_start_position):
+				write_subtitles = False
+				ser.write("{DEFAULT" + launch_state + "}")
+
+		if long(position) > long(start) and long(position) <= long(end):
+			if i > next_i:
+				next_i += 1
+			elif i == next_i:
+				#requires write_subtitles = True to account for launch_state
+				if write_subtitles == True:
+					ser.write(subtitles[language][i].content.encode("utf-8") + "\r")
+				next_i += 1
+		elif long(position) > long(end):
+			if subtitles[language][i] == subtitles[language][-1]:
+				i = 0
+				next_i = 0
+				if launch_state != "subtitles" and write_subtitles == True:
+					if(subtitle_duration == "1" or (subtitle_duration == "3" and played_through_once == True)):
+						#return dipslay to default state
+						write_subtitles = False
+						played_through_once = False
+						language = default_lang
+						ser.write("{DEFAULT" + launch_state + "}")
+					elif(subtitle_duration == "3" and played_through_once == False):
+						played_through_once = True
+					elif(subtitle_duration == "2"):
+						played_through_once = True
+				#update .count_plays (number of playthroughs)
+				with open(abs_path + '.count_plays', 'r') as count_video:
+					value = int(count_video.read())
+				with open(abs_path + '.count_plays', 'w') as count_video:
+					count_video.write(str(value + 1))
+
+				#write to /etc/motd
+				update_dashboard()
+			else:
+				i += 1
+		elif long(position) == 0:
 			i = 0
 			next_i = 0
-			if launch_state != "subtitles" and write_subtitles == True:
-				if(subtitle_duration == "1" or (subtitle_duration == "3" and played_through_once == True)):
-					#return dipslay to default state
-					write_subtitles = False
-					played_through_once = False
-					language = default_lang
-					ser.write("{DEFAULT" + launch_state + "}")
-				elif(subtitle_duration == "3" and played_through_once == False):
-					played_through_once = True
-				elif(subtitle_duration == "2"):
-					played_through_once = True
-			#update .count_plays (number of playthroughs)
-			with open(abs_path + '.count_plays', 'r') as count_video:
-				value = int(count_video.read())
-			with open(abs_path + '.count_plays', 'w') as count_video:
-				count_video.write(str(value + 1))
 
-			#write to /etc/motd
-			update_dashboard()
-		else:
-			i += 1
-	elif long(position) == 0:
-		i = 0
-		next_i = 0
+if __name__ == '__main__':
+	main()


### PR DESCRIPTION
In this pull request, I move all the imperative functionality of your script into a `main()` function. [(Read more here.)](http://effbot.org/pyfaq/tutor-what-is-if-name-main-for.htm)

You can see now that all your functions (`tc_to_ms`, `chop_digits`, ...) are defined at the same level. This may now help you think further about refactoring your code from the imperative style to the procedural style. Sometimes it's helpful to think in the procedural style because you can break down the work into smaller tasks.

You are kind of already doing this according to how you comment your blocks of code, but this is the formal way of doing it in code.